### PR TITLE
Updates to BPL PUI plugin

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -33,12 +33,13 @@ en:
           BPL’s finding aids have evolved over time in a range of formats; we are actively working to create more complete, equitable, and accessible collection descriptions.
         </p>
 
-        <h3>Requesting materials & Contact</h3>
+        <h3>Requesting materials</h3>
         <p>Please note that the Special Collections Reading Room is currently closed for renovations until 2022. Until then, collections are unavailable for in-person research.
         </p>
         <p>Collections at the Leventhal Map & Education Center are available for access. Please <a href="https://www.leventhalmap.org/research/appointments/" target="_blank">contact the department</a> to make a research appointment.
+        <h3>Contact us</h3>
         <p>
-          For questions about our collections, help navigating BPL finding aids, or to suggest changes to our descriptions, you can <a href="https://www.bpl.org/have-a-question-about-our-special-collections/" target="_blank">contact us directly</a>.
+          BPL Special Collections staff are always happy to connect. For questions about our collections, help navigating BPL finding aids, or to suggest changes to our descriptions, you can <a href="https://www.bpl.org/have-a-question-about-our-special-collections/" target="_blank">contact us directly</a>.
         </p>
 
         <hr />

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -6,20 +6,17 @@ en:
         <p>
           This site contains descriptions and inventories of the archival collections held by <a href="https://www.bpl.org/" target="_blank">Boston Public Library</a> and the
           <a href="https://www.leventhalmap.org/" target="_blank">Norman B. Leventhal Map & Education Center</a>.
-          Archives at BPL are described in <strong>finding aids</strong>, which include essential information about the creation, content, arrangement, and context of these collections.
-          <strong>Use this site to search and discover rare, distinctive, and culturally significant materials in BPL’s collections.</strong>
         </p>
-
+        <h4>What are archives?</h4>
         <p>
           An archival collection is a group of related materials that documents the activities of an individual, family, or organization.
           BPL archives include personal papers, records of local businesses and organizations, and subject-based collections, as well as the library’s institutional records.
-          Learn more about archives and finding aids on our <a href="help#about">Help page<a/>.
+          Archives at BPL are described in <strong>finding aids</strong>, which include essential information about the creation, content, arrangement, and context of these collections.
+          Learn more about archives and finding aids on our <a href="help#about">Help page</a>.
         </p>
-
+        <h4>Finding other rare, historic, and special collections at the BPL</h4>
         <p>
-          Rare books, manuscripts, maps, prints, drawings, music, and fine art are described in the <a href="https://catalog.mbln.org/Polaris/Search/default.aspx?ctx=1.1033.0.0.5&type=Advanced" target="_blank">research catalog</a> or in BPL’s <a href="https://guides.bpl.org/manuscripts/cardcatalogs" target="_blank">digitized card catalogs</a>.
-          Thousands of digitized objects are also available on <a href="https://www.digitalcommonwealth.org/institutions/commonwealth:sf268508b" target="_blank">Digital Commonwealth</a> and <a href="https://archive.org/details/bostonpubliclibrary">Internet Archive</a>.
-          Leventhal Map Center collections are discoverable through the Center’s <a href="https://www.leventhalmap.org/collections/" target="_blank">website</a>.
+          Rare books, manuscripts, maps, prints, drawings, music, and fine art are described in the <a href="https://catalog.mbln.org/Polaris/Search/default.aspx?ctx=1.1033.0.0.5&type=Advanced" target="_blank">research catalog</a> or in BPL’s <a href="https://guides.bpl.org/manuscripts/cardcatalogs" target="_blank">digitized card catalogs</a>. Thousands of digitized objects are also available on <a href="https://www.digitalcommonwealth.org/institutions/commonwealth:sf268508b" target="_blank">Digital Commonwealth</a> and <a href="https://archive.org/details/bostonpubliclibrary" target="_blank">Internet Archive</a>. Leventhal Map Center collections are discoverable through the Center’s <a href="https://www.leventhalmap.org/collections/" target="_blank">website</a>.
         </p>
 
         <p>
@@ -37,11 +34,9 @@ en:
         </p>
 
         <h3>Requesting materials & Contact</h3>
-        <p>
-          Please note that the Special Collections Reading Room is currently closed for renovations until 2022.
-          Until then, collections are unavailable for in-person research.
+        <p>Please note that the Special Collections Reading Room is currently closed for renovations until 2022. Until then, collections are unavailable for in-person research.
         </p>
-
+        <p>Collections at the Leventhal Map & Education Center are available for access. Please <a href="https://www.leventhalmap.org/research/appointments/" target="_blank">contact the department</a> to make a research appointment.
         <p>
           For questions about our collections, help navigating BPL finding aids, or to suggest changes to our descriptions, you can <a href="https://www.bpl.org/have-a-question-about-our-special-collections/" target="_blank">contact us directly</a>.
         </p>

--- a/public/views/search/search_results.html.erb
+++ b/public/views/search/search_results.html.erb
@@ -1,0 +1,101 @@
+<% results_type = (defined?(@results_type) ? @results_type : t('search_results.results')) %>
+<div class="row">
+  <div class="col-sm-12">
+     <%= render partial: 'shared/breadcrumbs' %>
+  <% if defined?(@search_title) %>
+  <h1><%= @search_title %></h1>
+  <% end %>
+
+  <% if defined?(@reset) && @reset %>
+      <%= render partial: 'shared/search', locals: {:search_url => @base_search,
+                                                    :title => t('archive._plural'),
+                                                    :limit_options => [["#{t('actions.search')} #{t('search-limits.all')}",''],
+                                                                       [t('search-limit', :limit => t('search-limits.resources')),'resource']],
+                                                    :field_options => [["#{t('search_results.filter.fullrecord')}",''],
+                                                                       ["#{t('search_results.filter.title')}",'title'],
+                                                                       ["#{t('search_results.filter.creators')}",'creators_text'],
+                                                                       ["#{t('search_results.filter.subjects')}",'subjects_text'],
+                                                                       ["#{t('search_results.filter.identifier')}", 'four_part_id'] ],
+                                                    :header_size => '2',
+                                                    :show_header => true } %>
+  <% else %>
+
+  <% unless defined?(@no_statement) %>
+    <div class="searchstatement">
+      <div class="btn btn-group pull-right">
+        <%= link_to I18n.t('actions.new_search'), (defined?(@new_search) ? @new_search : root_path), :class => "btn btn-sm btn-default" %>
+        <button class="btn btn-sm btn-default" id="toggleRefineSearch" aria-expanded="false" aria-controls="refineSearchPanel"><%= I18n.t('actions.refine_search') %></button>
+      </div>
+
+      <% if defined?(@search) %>
+        <%= @search[:search_statement].html_safe %>
+      <% end %>
+
+      <div id="refineSearchPanel" class="container refinesearch" aria-hidden="true" style="display:none;">
+        <%= render partial: 'shared/search', locals: {:search_url => @base_search,
+                                                      :title => t('archive._plural'),
+                                                      :limit_options => [["#{t('actions.search')} #{t('search-limits.all')}",''],
+                                                                         [t('search-limit', :limit => t('search-limits.resources')),'resource']],
+                                                      :field_options => [["#{t('search_results.filter.fullrecord')}",''],
+                                                                         ["#{t('search_results.filter.title')}",'title'],
+                                                                         ["#{t('search_results.filter.creators')}",'creators_text'],
+                                                                         ["#{t('search_results.filter.subjects')}",'subjects_text'],
+                                                                         ["#{t('search_results.filter.identifier')}", 'four_part_id'] ],
+                                                      :show_header => false } %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if defined?(@results) %>
+  <h1><%= t('search_results.results_head', {:type => results_type, :start => @results['offset_first'],
+         :end => @results['offset_last'], :total => @results['total_hits'] })  %></h1>
+  <% end %>
+  <% end %>
+  </div>
+</div>
+
+<%#  mdc: new stuff, per S&E group %>
+<% if ['Subjects', 'Names'].include?(@results_type) %>
+<div class="row">
+  <div class="col-sm-12">
+    <% if @results_type == 'Subjects' %>
+     <%= t('brand.subject_intro').html_safe %>
+    <% elsif @results_type == 'Names' %>
+     <%= t('brand.agent_intro').html_safe %>
+    <% end %>
+  </div>
+</div>
+<% end %>
+
+<% if defined?(@results) %>
+<div class="row">
+  <%#  mdc: put facets first %>
+  <div class="col-sm-3">
+    <a name="filter" title="<%= t('internal_links.filter') %>"></a>
+    <%= render partial: 'shared/facets' %>
+  </div>
+
+  <div class="col-sm-9">
+    <a name="main" title="<%= t('internal_links.main') %>"></a>
+    <div class="row"><div class="col-sm-8">
+    <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
+    </div>
+    <%= render partial: 'shared/sorter' %>
+
+</div>
+    <div class="row search-results"><div class="col-sm-12">
+
+    <a name="searchresults" id="searchresults"></a>
+
+    <% @results.records.each do |result| %>
+      <%= render partial: 'shared/result', locals: {:result => result, :props => (@result_props || {}).merge({:full => false})} %>
+    <% end %>
+    </div></div>
+    <div class="row"><div class="col-sm-9">
+    <%= render partial: 'shared/pagination', locals: {:pager  => @pager, :pager_id => 'paging_bottom'}  %>
+    </div></div>
+  </div>
+
+
+</div>
+<% end %>

--- a/public/views/shared/_navigation.html.erb
+++ b/public/views/shared/_navigation.html.erb
@@ -1,0 +1,50 @@
+<%#mdc: should the aria-labels be pulled from the YML files, instead???
+for now i just pulled up the aria-label and added it to the section element %>
+<section id="navigation" aria-label="primary navigation links">
+  <nav class="navbar navbar-default">
+    <div class="container-fluid navbar-header top-bar">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsemenu"
+              aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="collapsemenu">
+        <ul class="nav nav navbar-nav">
+          <%# new stuff... add to plugin, later
+          and also make sure the link is not active when
+          on homepage (or just remove this link altogether
+          since it duplicates the div.h1 link) %>
+
+          <%# (change the bit after proxy_url if this section is uncommented,
+          in order to add the Home link back.)
+          <li>
+            <a href="<%= AppConfig[:public_proxy_url] >" title="Archives at Yale">
+                <span>Home</span>
+                <span class="sr-only">Return to Homepage</span>
+              </a>
+          </li>
+          %>
+
+          <li>
+            <a href="<%= app_prefix("/repositories/2") %>">
+              <%= t('repository._plural') %> </a>
+          </li>
+
+          <%# TODO: add class="active" if we're on that page %>
+          <% $MAIN_MENU.drop(1).each do |link| %>
+            <li><a href="<%= app_prefix(link[0]) %>"><%= t(link[1]) %></a></li>
+          <% end %>
+          <% unless AppConfig[:pui_hide][:search_tab] %>
+            <li><a href="<%=  app_prefix('/search?reset=true') %>" title="<%= I18n.t('search_tab', :target => t('archive._plural'))%>">
+                <span class="fa fa-search" aria-hidden="true"></span>
+                <span class="sr-only"><%= I18n.t('search_tab', :target => t('archive._plural')) %></span>
+              </a>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</section>

--- a/public/views/welcome/show.html.erb
+++ b/public/views/welcome/show.html.erb
@@ -1,0 +1,33 @@
+<%# adjusted html a bit, and added container-fluid
+since that's where the 15px margin-left is at, for whatever reason %>
+<div class="row container-fluid">
+  <h1><%= t('brand.welcome_head') %></h1>
+</div>
+
+<%# mdc: removed digital object limit manually, since it's added here.
+would like to be add something like this:
+[t('search-limit', :limit => 'Beinecke'),'',:search_url => "repositories/{repo_id}/search"]
+but we can't pass the search_url parameter as a limit option right now
+%>
+
+<%= render partial: 'shared/search', locals: {
+  :search_url => "/search",
+  :title => t('archive._plural'),
+  :limit_options => [
+        ["#{t('actions.search')} #{t('search-limits.all')}",''],
+        [t('search-limit', :limit => t('search-limits.resources')),'resource']
+      ],
+  :field_options => [
+        ["#{t('search_results.filter.fullrecord')}",''],
+        ["#{t('search_results.filter.title')}",'title'],
+        ["#{t('search_results.filter.creators')}",'creators_text'],
+        ["#{t('search_results.filter.subjects')}",'subjects_text'],
+        ["#{t('search_results.filter.identifier')}", 'four_part_id']
+       ]
+} %>
+
+<%# moved to the bottom; updated the YML file with slightly better HTML
+but not sure if that HTML should be in a YML file! %>
+<div class="row">
+ <%= t('brand.welcome_message').html_safe %>
+</div>


### PR DESCRIPTION
I have added some Yale-pui-plugin items back into our BPL pui css plugin via the github commit  to accomplish the following:
- move search bar to top of home page (above welcome text)
- Edits to welcome text (en.yml file edits for home page)
- Edit how the repositories link in the top nav menu directs: should direct straight to repositories/2 instead of the list of repos (since we only have one)
- Move facets to the left side of the page on the search results page
- Change search option delimiters in search form on the following pages (remove limit to digital materials, remove search notes field)
        - Home page
        - Search page
        - Search results page (edit search)
	
	
	 